### PR TITLE
Updating ssn encryption to be non-deterministic

### DIFF
--- a/src/main/java/org/ladocuploader/app/inputs/LaDocUpload.java
+++ b/src/main/java/org/ladocuploader/app/inputs/LaDocUpload.java
@@ -38,9 +38,7 @@ public class LaDocUpload extends FlowInputs {
   @Pattern(regexp = "^[0-9]*$", message = "{client-info.number-format}")
   private String caseNumber;
 
-  @Size(min=11, max=11, message="{client-info.provide-9-digit-ssn}")
+  @Size(min = 11, max = 11, message = "{client-info.provide-9-digit-ssn}")
   private String ssn;
-
-
 }
 

--- a/src/main/java/org/ladocuploader/app/submission/StringEncryptor.java
+++ b/src/main/java/org/ladocuploader/app/submission/StringEncryptor.java
@@ -1,42 +1,75 @@
 package org.ladocuploader.app.submission;
 
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.apache.commons.codec.binary.Base64;
 
 public class StringEncryptor {
 
+  public static final int BLOCK_SIZE = 128;
+
   private final SecretKey secretKey;
+  private byte[] iv;
+
+  Cipher desCipher;
 
   public StringEncryptor(String key) {
-    secretKey = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
+    try {
+      secretKey = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
+      desCipher = Cipher.getInstance("AES/GCM/NoPadding");
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+      throw new IllegalStateException("Unable to initialize encryptor", e);
+    }
+  }
+
+  public StringEncryptor(String key, byte[] ivParam) {
+    try {
+      secretKey = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
+      desCipher = Cipher.getInstance("AES/GCM/NoPadding");
+      iv = ivParam;
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+      throw new IllegalStateException("Unable to initialize encryptor", e);
+    }
   }
 
   public String decrypt(String input) {
-    byte[] bytes = runEncryption(Cipher.DECRYPT_MODE, Base64.decodeBase64(input));
+    byte[] bytes = runEncryption(Cipher.DECRYPT_MODE, Base64.decodeBase64(input), iv);
     return new String(bytes);
   }
 
   public String encrypt(String input) {
-    byte[] bytes = runEncryption(Cipher.ENCRYPT_MODE, input.getBytes());
+    byte[] bytes = runEncryption(Cipher.ENCRYPT_MODE, input.getBytes(), generateNewIv());
     return new String(Base64.encodeBase64(bytes));
   }
 
-  private byte[] runEncryption(int mode, byte[] input) {
+  private byte[] runEncryption(int mode, byte[] input, byte[] iv) {
     try {
-      Cipher desCipher = Cipher.getInstance("AES");
-      desCipher.init(mode, secretKey);
+      desCipher.init(mode, secretKey, new GCMParameterSpec(BLOCK_SIZE, iv));
       return desCipher.doFinal(input);
-    } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
-             BadPaddingException | IllegalBlockSizeException e) {
+    } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException |
+             InvalidAlgorithmParameterException e) {
       throw new IllegalStateException(e);
     }
+  }
+
+  private byte[] generateNewIv() {
+    SecureRandom randomSecureRandom = new SecureRandom();
+    iv = new byte[BLOCK_SIZE];
+    randomSecureRandom.nextBytes(iv);
+    return iv;
+  }
+
+  public String getIV() {
+    return new String(Base64.encodeBase64(iv));
   }
 }

--- a/src/main/java/org/ladocuploader/app/submission/actions/EncryptSSNBeforeSaving.java
+++ b/src/main/java/org/ladocuploader/app/submission/actions/EncryptSSNBeforeSaving.java
@@ -19,6 +19,7 @@ public class EncryptSSNBeforeSaving implements Action {
     if (ssnInput != null) {
       String encryptedSSN = encryptor.encrypt(ssnInput);
       submission.getInputData().put("encryptedSSN", encryptedSSN);
+      submission.getInputData().put("encryptedSSN_iv", encryptor.getIV());
     }
   }
 }

--- a/src/test/java/org/ladocuploader/app/submission/StringEncryptorTest.java
+++ b/src/test/java/org/ladocuploader/app/submission/StringEncryptorTest.java
@@ -7,16 +7,22 @@ import org.junit.jupiter.api.Test;
 
 class StringEncryptorTest {
 
-  StringEncryptor encryptor = new StringEncryptor("some-secret-key-that-is-32-bytes");
-
   @Test
   void testEncryptDecrypt() {
+    StringEncryptor encryptor = new StringEncryptor("some-secret-key-that-is-32-bytes");
+    StringEncryptor encryptor2 = new StringEncryptor("some-secret-key-that-is-32-bytes");
+
     String input = "this is not encrypted";
     String encrypted = encryptor.encrypt(input);
+    String encrypted2 = encryptor2.encrypt(input);
     String decrypted = encryptor.decrypt(encrypted);
+    String decrypted2 = encryptor2.decrypt(encrypted2);
 
     assertNotEquals(encrypted, decrypted);
+    assertNotEquals(encrypted, encrypted2);
     assertEquals(input, decrypted);
+    assertEquals(input, decrypted2);
+
   }
 
 }


### PR DESCRIPTION
### What ###
Update ssn encryption to be non-deterministic 

### Why ###
(from security-advocates)
Best practices
- Not storing SSN at all (like the cvc on credit cards)
- Avoid determinism - opt for 1-way hash for data science matching if needed
- Java has good security primitives - use the full power.
- “Expire” SSN after a period of time



[PT#184982425]