### PR TITLE
Fixes an issue with recent chrome browser binary path changes

### DIFF
--- a/src/test/java/org/ladocuploader/app/utils/SeleniumFactory.java
+++ b/src/test/java/org/ladocuploader/app/utils/SeleniumFactory.java
@@ -39,6 +39,7 @@ public class SeleniumFactory implements FactoryBean<RemoteWebDriver> {
     Map<String, Object> chromePrefs = new HashMap<>();
     chromePrefs.put("download.default_directory", tempdir.toString());
     options.setExperimentalOption("prefs", chromePrefs);
+    options.setBinary(WebDriverManager.chromedriver().getBrowserPath().get().toString());
     options.addArguments("--window-size=1280,1600");
     options.addArguments("--headless=new");
     options.addArguments("--remote-allow-origins=*");


### PR DESCRIPTION

This fixes tests so they run again.  As of major version 115, chrome changed where the binary is located.  

This allowed me to run tests locally again. 