### PR TITLE
Fix max filesize check inconsistency 

### DIFF
--- a/src/main/resources/static/assets/js/dropzone.js
+++ b/src/main/resources/static/assets/js/dropzone.js
@@ -1871,8 +1871,8 @@ function (_Emitter) {
   }, {
     key: "accept",
     value: function accept(file, done) {
-      if (this.options.maxFilesize && file.size > this.options.maxFilesize * 1024 * 1024) {
-        done(this.options.dictFileTooBig.replace("{{filesize}}", Math.round(file.size / 1024 / 10.24) / 100).replace("{{maxFilesize}}", this.options.maxFilesize));
+      if (this.options.maxFilesize && file.size > this.options.maxFilesize * this.options.filesizeBase * this.options.filesizeBase) {
+        done(this.options.dictFileTooBig.replace("{{filesize}}", Math.round(file.size / this.options.filesizeBase / 1.0) / this.options.filesizeBase).replace("{{maxFilesize}}", this.options.maxFilesize));
       } else if (!Dropzone.isValidFile(file, this.options.acceptedFiles)) {
         done(this.options.dictInvalidFileType);
       } else if (this.options.maxFiles != null && this.getAcceptedFiles().length >= this.options.maxFiles) {


### PR DESCRIPTION
Overriding dropzone.js to use configuration for filesize base to avoid inconsistency with tomcat filesize limit