### PR TITLE
Disabling digital assister flow for prod

### DIFF
--- a/src/main/resources/application-demo.yaml
+++ b/src/main/resources/application-demo.yaml
@@ -4,5 +4,6 @@ spring:
   datasource:
     url: jdbc:postgresql://host.docker.internal:5432/la-doc-uploader
 form-flow:
+  disabled-flows: ~
   uploads:
     max-file-size: '5'

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,2 @@
+form-flow:
+  disabled-flows: ~

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -7,5 +7,6 @@ management:
   endpoints:
     enabled-by-default: false
 form-flow:
+  disabled-flows: ~
   uploads:
     max-file-size: '5'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,7 @@
 form-flow:
+  disabled-flows:
+    - flow: laDigitalAssister
+      staticRedirectPage: /
   pdf:
     path: ~
   inputs: 'org.ladocuploader.app.inputs.'


### PR DESCRIPTION
Disabled the digital assister flow for prod only. This is still available in dev, demo, staging, test