### PR TITLE
Updates the  the code to work with recent FFB library 0.0.15 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 }
 
 def profile = props.getProperty('SPRING_PROFILES_ACTIVE')
-def formFlowLibraryVersion = '0.0.14'
+def formFlowLibraryVersion = '0.0.15'
 def useLocalLibrary = System.getenv('USE_LOCAL_LIBRARY')
 
 dependencies {
@@ -41,13 +41,13 @@ dependencies {
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.3'
 
-    if (profile == 'dev' || useLocalLibrary == 'true') {
-        implementation fileTree(dir: "$rootDir/../form-flow/build/libs", include: '*.jar')
-        println "📦 Using local library"
-    } else {
+ //   if (profile == 'dev' || useLocalLibrary == 'true') {
+  //      implementation fileTree(dir: "$rootDir/../form-flow/build/libs", include: '*.jar')
+  //      println "📦 Using local library"
+  //  } else {
         implementation "org.codeforamerica.platform:form-flow:${formFlowLibraryVersion}"
         println "📚Using form flow library ${formFlowLibraryVersion}"
-    }
+   // }
 
     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
     testImplementation 'org.projectlombok:lombok:1.18.30'

--- a/build.gradle
+++ b/build.gradle
@@ -41,13 +41,13 @@ dependencies {
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.3'
 
- //   if (profile == 'dev' || useLocalLibrary == 'true') {
-  //      implementation fileTree(dir: "$rootDir/../form-flow/build/libs", include: '*.jar')
-  //      println "📦 Using local library"
-  //  } else {
+    if (profile == 'dev' || useLocalLibrary == 'true') {
+        implementation fileTree(dir: "$rootDir/../form-flow/build/libs", include: '*.jar')
+        println "📦 Using local library"
+    } else {
         implementation "org.codeforamerica.platform:form-flow:${formFlowLibraryVersion}"
         println "📚Using form flow library ${formFlowLibraryVersion}"
-   // }
+    }
 
     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
     testImplementation 'org.projectlombok:lombok:1.18.30'

--- a/src/main/java/org/ladocuploader/app/inputs/LaDigitalAssister.java
+++ b/src/main/java/org/ladocuploader/app/inputs/LaDigitalAssister.java
@@ -1,7 +1,7 @@
 package org.ladocuploader.app.inputs;
 
 import formflow.library.data.FlowInputs;
-import formflow.library.data.validators.Money;
+import formflow.library.data.annotations.Money;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/resources/templates/fragments/inputs/repAddress.html
+++ b/src/main/resources/templates/fragments/inputs/repAddress.html
@@ -6,7 +6,7 @@
     city=${inputName + T(formflow.library.inputs.AddressParts).CITY.toString()},
     state=${inputName + T(formflow.library.inputs.AddressParts).STATE.toString()},
     zipCode=${inputName + T(formflow.library.inputs.AddressParts).ZIPCODE.toString()},
-    validateAddressInputName=${T(formflow.library.inputs.UnvalidatedField).VALIDATE_ADDRESS + inputName}"
+    validateAddressInputName=${T(formflow.library.inputs.FieldNameMarkers).UNVALIDATED_FIELD_MARKER_VALIDATE_ADDRESS + inputName}"
 >
   <th:block th:replace="~{fragments/inputs/text ::
                   text(inputName=${streetAddress},

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -19,6 +19,7 @@ spring:
     clean-on-validation-error: true
     placeholders:
       uuid_function: "gen_random_uuid"
+      user_file_doc_type_default_label: ${form-flow.uploads.default-doc-type-label:#{null}}
     clean-disabled: false
   thymeleaf:
     prefix: classpath:/templates/

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,4 +1,5 @@
 form-flow:
+  disabled-flows: ~
   uploads:
     accepted-file-types: '.jpeg,.jpg,.png,.pdf,.bmp,.gif,.doc,.docx,.odt,.ods,.odp'
     thumbnail-width: '54'


### PR DESCRIPTION
Updates the code to work with the new FFB Library 0.0.15 release. 

 * The work we did for the doc type label is in this release.
 * This also makes the work in this PR to disable a flow go live: https://github.com/codeforamerica/la-doc-uploader/pull/392

We are not using the doc type label feature currently and have closed our doc type branch, but the logic we added to the FFB library did get in, so we need to update this code with some small changes. 