### PR TITLE
Implement experiment sorting

### DIFF
--- a/src/main/java/org/ladocuploader/app/submission/actions/SetExperimentGroups.java
+++ b/src/main/java/org/ladocuploader/app/submission/actions/SetExperimentGroups.java
@@ -1,0 +1,27 @@
+package org.ladocuploader.app.submission.actions;
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import java.util.Random;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SetExperimentGroups implements Action {
+  
+  public enum ExperimentGroup {
+    CONTROL,
+    LINK,
+    APPLY
+  }
+  
+  @Override
+  public void run(Submission submission) {
+    Random rand = new Random();
+    int group = rand.nextInt(3);
+    switch(group) {
+      case 0 -> submission.getInputData().put("experimentGroup", ExperimentGroup.CONTROL);
+      case 1 -> submission.getInputData().put("experimentGroup", ExperimentGroup.LINK);
+      case 2 -> submission.getInputData().put("experimentGroup", ExperimentGroup.APPLY);
+    }
+  }
+}

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -29,6 +29,7 @@ flow:
     nextScreens:
       - name: languagePreference
   languagePreference:
+    beforeSaveAction: SetExperimentGroups
     nextScreens:
       - name: choosePrograms
   choosePrograms:

--- a/src/test/java/org/ladocuploader/app/submission/actions/SetExperimentGroupsTest.java
+++ b/src/test/java/org/ladocuploader/app/submission/actions/SetExperimentGroupsTest.java
@@ -1,0 +1,21 @@
+package org.ladocuploader.app.submission.actions;
+
+
+import formflow.library.config.submission.Action;
+import formflow.library.data.Submission;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ladocuploader.app.submission.actions.SetExperimentGroups.ExperimentGroup.*;
+
+class SetExperimentGroupsTest {
+
+  @Test
+  void shouldSetExperimentGroupToControlLinkOrApply() {
+    Submission submission = new Submission();
+    Action setExperimentGroups = new SetExperimentGroups();
+    setExperimentGroups.run(submission);
+    assertThat(submission.getInputData().get("experimentGroup")).isNotNull();
+    assertThat(submission.getInputData().get("experimentGroup")).isIn(APPLY, CONTROL, LINK);
+  }
+}


### PR DESCRIPTION
This PR implements a beforeSaveAction `SetExperimentGroups` that runs on the first post in the digital assister flow (the Language Preferences page). The `SetExperimentGroups` action uses an enum with values CONTROL, LINK and, APPLY along with a simple algorithm that randomly assigns one of the three enum values.

The assigned value is stored in the Submissions input data JSON as `experimentGroup`.