### PR TITLE
WIC/ECE Treatment 1 - links

### DIFF
--- a/src/main/java/org/ladocuploader/app/inputs/LaDigitalAssister.java
+++ b/src/main/java/org/ladocuploader/app/inputs/LaDigitalAssister.java
@@ -354,6 +354,10 @@ public class LaDigitalAssister extends FlowInputs {
   @NotBlank(message="{error.missing-dollar-amount}")
   private String expensesElderlyCare;
 
+  // WIC / ECE
+  private String interestedInEceInd;
+  private String interestedInWicInd;
+
   // Final Screen
   private String authorizedRepresentative;
 

--- a/src/main/java/org/ladocuploader/app/submission/conditions/EligibleForNolaWicEceLinks.java
+++ b/src/main/java/org/ladocuploader/app/submission/conditions/EligibleForNolaWicEceLinks.java
@@ -1,0 +1,18 @@
+package org.ladocuploader.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
+
+import static org.ladocuploader.app.submission.actions.SetExperimentGroups.ExperimentGroup.LINK;
+import static org.ladocuploader.app.utils.SubmissionUtilities.inExperimentGroup;
+import static org.ladocuploader.app.utils.SubmissionUtilities.isNolaParish;
+
+@Component
+public class EligibleForNolaWicEceLinks implements Condition {
+
+  @Override
+  public Boolean run(Submission submission) {
+    return isNolaParish(submission) && inExperimentGroup(LINK.name(), submission);
+  }
+}

--- a/src/main/java/org/ladocuploader/app/submission/conditions/EligibleForOutsideNolaWicEceLinks.java
+++ b/src/main/java/org/ladocuploader/app/submission/conditions/EligibleForOutsideNolaWicEceLinks.java
@@ -1,0 +1,18 @@
+package org.ladocuploader.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
+
+import static org.ladocuploader.app.submission.actions.SetExperimentGroups.ExperimentGroup.LINK;
+import static org.ladocuploader.app.utils.SubmissionUtilities.inExperimentGroup;
+import static org.ladocuploader.app.utils.SubmissionUtilities.isNolaParish;
+
+@Component
+public class EligibleForOutsideNolaWicEceLinks implements Condition {
+
+  @Override
+  public Boolean run(Submission submission) {
+    return !isNolaParish(submission) && inExperimentGroup(LINK.name(), submission);
+  }
+}

--- a/src/main/java/org/ladocuploader/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/ladocuploader/app/utils/SubmissionUtilities.java
@@ -80,11 +80,11 @@ public class SubmissionUtilities {
     }
 
     public static boolean isNolaParish(Submission submission) {
-        return ORLEANS.name().equals(submission.getInputData().getOrDefault("parish", ""));
+        return ORLEANS.name().equals(submission.getInputData().get("parish"));
     }
 
     public static boolean inExperimentGroup(String groupName, Submission submission) {
-        return groupName.equals(submission.getInputData().getOrDefault("experimentGroup", ""));
+        return groupName.equals(submission.getInputData().get("experimentGroup"));
     }
 
     public static String householdMemberFullName(Map<String, String> householdMember) {

--- a/src/main/java/org/ladocuploader/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/ladocuploader/app/utils/SubmissionUtilities.java
@@ -6,13 +6,13 @@ import java.text.DecimalFormat;
 import java.util.*;
 
 import static formflow.library.inputs.FieldNameMarkers.DYNAMIC_FIELD_MARKER;
+import static org.ladocuploader.app.utils.Parish.ORLEANS;
 
 public class SubmissionUtilities {
     public static final String ENCRYPTED_SSNS_INPUT_NAME = "householdMemberEncryptedSSN";
 
     public static final Map<String, String> PDF_EDUCATION_MAP = new HashMap<>();
     public static final Map<String, String> PDF_MARITAL_STATUS_MAP = new HashMap<>();
-
     public static final Map<String, String> PDF_RELATIONSHIP_MAP = new HashMap<>();
 
     static {
@@ -77,6 +77,14 @@ public class SubmissionUtilities {
     public static String formatMoney(Double value) {
         DecimalFormat decimalFormat = new DecimalFormat("###.##");
         return "$" + decimalFormat.format(value);
+    }
+
+    public static boolean isNolaParish(Submission submission) {
+        return ORLEANS.name().equals(submission.getInputData().getOrDefault("parish", ""));
+    }
+
+    public static boolean inExperimentGroup(String groupName, Submission submission) {
+        return groupName.equals(submission.getInputData().getOrDefault("experimentGroup", ""));
     }
 
     public static String householdMemberFullName(Map<String, String> householdMember) {

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -610,8 +610,22 @@ flow:
     nextScreens:
       - name: expensesElderlyCareAmount
         condition: HasElderlyCareExpenses
+      - name: nolaEceLinks
+        condition: EligibleForNolaWicEceLinks
+      - name: eceLinks
+        condition: EligibleForOutsideNolaWicEceLinks
       - name: finalSignPost
   expensesElderlyCareAmount:
+    nextScreens:
+      - name: nolaEceLinks
+        condition: EligibleForNolaWicEceLinks
+      - name: wicLinks
+        condition: EligibleForOutsideNolaWicEceLinks
+      - name: finalSignPost
+  nolaEceLinks:
+    nextScreens:
+      - name: wicLinks
+  wicLinks:
     nextScreens:
       - name: finalSignPost
   finalSignPost:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1108,14 +1108,14 @@ share-wic-button=Share my data with WIC
 you-can-finish-up-2=You can finish up your SNAP application, and receive next steps for all applications at the end.
 
 # WIC / ECE
-nola.title=ECE
+nola-ece-links.title=ECE link
 nola-ece-links.if-youre-approved=If you\u2019re approved for SNAP, you\u2019re also eligible for free childcare and pre-K.
 nola-ece-links.subheader=These programs can:<ul class="list--bulleted"> <li>Provide free childcare and education for children from birth through age 4</li> <li>Provide free pre-K in public or private school for 4-year-olds</li></ul>
 nola-ece-links.at-the-end-of-this-app=At the end of this application, we\u2019ll show you a clickable link to the NOLA Public Schools application (enrollnolaps.com).
 nola-ece-links.are-you-interested=Are you interested in free childcare or pre-K?
 nola-ece-go-to-application=Go to the ECE application
 
-wic.title=WIC
+wic-links.title=WIC link
 wic.if-youre-approved=If you\u2019re approved for SNAP, you\u2019re also eligible for the Women, Infants, and Children (WIC) program.
 wic.subheader=WIC can:<ul class="list--bulleted"> <li>Provide infant formula</li> <li>Provide a WIC EBT card for healthy food</li> <li>Provide nutrition education</li></ul>
 wic-links.at-the-end-of-this-app=At the end of this application, we\u2019ll show you a clickable link to the WIC application (surveymonkey.com/r/LAWIC_InterestForm).

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -18,7 +18,7 @@ general.optional=Optional.
 general.check-all-that-apply=Check all that apply.
 general.you=(You)
 general.none-of-the-above=None of the above
-general.continue-with-snap-only=Continue with SNAP only
+general.good-news=Good news!
 error.error=Error
 error.uh-oh=Uh oh!
 error.we-are-sorry=We're sorry, but something went wrong. Please try again later.
@@ -1109,13 +1109,23 @@ you-can-finish-up-2=You can finish up your SNAP application, and receive next st
 
 # WIC / ECE
 nola.title=ECE
-nola-ece-links.header=You might qualify for ECE
-nola-ece-links.subheader=Based on your answers, you might qualify for <b>Early Childhood and Education (ECE)</b>. ECE can:<ul class="list--bulleted"> <li>Provide free childcare</li> <li>Provide free pre-K education</li></ul>
-nola-ece-links-button=Open the ECE application
+nola-ece-links.if-youre-approved=If you\u2019re approved for SNAP, you\u2019re also eligible for free childcare and pre-K.
+nola-ece-links.subheader=These programs can:<ul class="list--bulleted"> <li>Provide free childcare and education for children from birth through age 4</li> <li>Provide free pre-K in public or private school for 4-year-olds</li></ul>
+nola-ece-links.at-the-end-of-this-app=At the end of this application, we\u2019ll show you a clickable link to the NOLA Public Schools application (enrollnolaps.com).
+nola-ece-links.are-you-interested=Are you interested in free childcare or pre-K?
+nola-ece-go-to-application=Go to the ECE application
 
 wic.title=WIC
-wic.header=If you\u2019re approved for SNAP, you\u2019re also eligible for WIC.
-wic-links-button=Open the WIC application
+wic.if-youre-approved=If you\u2019re approved for SNAP, you\u2019re also eligible for the Women, Infants, and Children (WIC) program.
+wic.subheader=WIC can:<ul class="list--bulleted"> <li>Provide infant formula</li> <li>Provide a WIC EBT card for healthy food</li> <li>Provide nutrition education</li></ul>
+wic-links.at-the-end-of-this-app=At the end of this application, we\u2019ll show you a clickable link to the WIC application (surveymonkey.com/r/LAWIC_InterestForm).
+wic-links.are-you-interested=Are you interested in the WIC nutrition program?
+wic-go-to-application=Go to the WIC application
+
+ece-yes-confirmation.header=Here is the link for submitting an application for free childcare and pre-K!
+ece-no-confirmation.header=Here\u2019s one more chance to apply for free childcare and pre-K.
+wic-yes-confirmation.header=Here is the link for submitting an application for the Women, Infants, and Children (WIC) program!
+wic-no-confirmation.header=Here\u2019s one more chance to apply for the WIC nutrition program.
 
 you-might-qualify-wic=You might qualify for Women, Infant, and Children (WIC)
 go-to-wic-button=Go to the WIC application

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -18,6 +18,7 @@ general.optional=Optional.
 general.check-all-that-apply=Check all that apply.
 general.you=(You)
 general.none-of-the-above=None of the above
+general.continue-with-snap-only=Continue with SNAP only
 error.error=Error
 error.uh-oh=Uh oh!
 error.we-are-sorry=We're sorry, but something went wrong. Please try again later.
@@ -938,7 +939,7 @@ final-signpost.content-4=Agreeing to terms
 #EBT
 ebtcard-title=EBT Card
 ebtcard-header=Do you need a new EBT card?
-ebtcard-subheader=You can use your EBT (Electronic Benefits Transfer) card to pay for groceries if you?re approved for SNAP.
+ebtcard-subheader=You can use your EBT (Electronic Benefits Transfer) card to pay for groceries if you're approved for SNAP.
 
 authorized-rep.title=Authorized Representative
 authorized-rep.header=Do you want to assign someone to be your authorized representative?
@@ -1100,16 +1101,21 @@ wic-will-contact=WIC staff will contact you to complete the application process.
 thank-you=Thank you for your information
 you-can-finish-up=You can finish up your SNAP application, and receive next steps for all programs at the end.
 
-based-on-your-answers=Based on your answers, you might qualify for <b>Women, Infants, and Children (WIC)</b>. WIC can:<ul><li>Give nutrition education</li> <li>Refer you to healthcare</li> <li>Help you pay for healthy foods</li></ul> Would you like to share your data with WIC to see if you qualify?
+wic.based-on-your-answers=Based on your answers, you might qualify for <b>Women, Infants, and Children (WIC)</b>. WIC can:<ul class="list--bulleted"><li>Give nutrition education</li> <li>Refer you to healthcare</li> <li>Help you pay for healthy foods</li></ul>
+wic.would-you-like-share-data=Would you like to share your data with WIC to see if you qualify?
 share-wic-button=Share my data with WIC
 
 you-can-finish-up-2=You can finish up your SNAP application, and receive next steps for all applications at the end.
 
-you-might-qualify-for-ece=You might qualify for ECE
-you-might-qualify-for-ece-subheader=Based on your answers, you might qualify for <b>Early Childhood and Education (ECE)</b>. ECE can:<ul> <li>Provide free childcare</li> <li>Provide free pre-K education</li></ul>
-open-ece-button=Open the ECE application
+# WIC / ECE
+nola.title=ECE
+nola-ece-links.header=You might qualify for ECE
+nola-ece-links.subheader=Based on your answers, you might qualify for <b>Early Childhood and Education (ECE)</b>. ECE can:<ul class="list--bulleted"> <li>Provide free childcare</li> <li>Provide free pre-K education</li></ul>
+nola-ece-links-button=Open the ECE application
 
-open-wic-button=Open the WIC application
+wic.title=WIC
+wic.header=If you\u2019re approved for SNAP, you\u2019re also eligible for WIC.
+wic-links-button=Open the WIC application
 
 you-might-qualify-wic=You might qualify for Women, Infant, and Children (WIC)
 go-to-wic-button=Go to the WIC application

--- a/src/main/resources/static/assets/css/custom.css
+++ b/src/main/resources/static/assets/css/custom.css
@@ -220,13 +220,14 @@ input[type="number"] {
   border: 1px solid #003865;
   border-radius: 3px;
   position: relative;
-  padding: 20px 15px 0 15px;
+  padding: 20px 15px;
 }
 
 .steps-box {
   display: flex;
   align-items: flex-start;
   gap: 20px;
+  padding-bottom: 0;
 }
 
 .steps-box svg {

--- a/src/main/resources/templates/fragments/inputs/yesOrNo.html
+++ b/src/main/resources/templates/fragments/inputs/yesOrNo.html
@@ -2,10 +2,12 @@
     th:fragment="yesOrNo(inputName, ariaDescribe)"
     th:with="
       hasHelpText=${!#strings.isEmpty(helpText)},
+      hasLabel=${!#strings.isEmpty(label)},
       hasAriaDescribe=${!#strings.isEmpty(ariaDescribe)},
       hasYesText=${!#strings.isEmpty(overrideYesText)},
       hasNoText=${!#strings.isEmpty(overrideNoText)}"
     th:assert="${!#strings.isEmpty(inputName)}, ${hasAriaDescribe}">
+  <label th:if="${hasLabel}" th:for="${inputName}" th:text="${label}" class="form-question"/>
   <div th:if="${hasHelpText}">
     <p th:id="${inputName + '-help-text'}"
        th:text="${helpText}"

--- a/src/main/resources/templates/fragments/wicEceConfirmation.html
+++ b/src/main/resources/templates/fragments/wicEceConfirmation.html
@@ -1,0 +1,37 @@
+<th:block th:fragment="wicEceConfirmation">
+    <th:block th:with="
+        inNola=${T(org.ladocuploader.app.utils.SubmissionUtilities).isNolaParish(submission)},
+        inLinkGroup=${T(org.ladocuploader.app.utils.SubmissionUtilities).inExperimentGroup('LINK', submission)},
+        inApplyGroup=${T(org.ladocuploader.app.utils.SubmissionUtilities).inExperimentGroup('APPLY', submission)},
+        isInterestedInECE=${inputData.getOrDefault('interestedInEceInd','false')},
+        isInterestedInWIC=${inputData.getOrDefault('interestedInWicInd','false')}">
+
+        <th:block th:if="${inNola && inLinkGroup}">
+            <hr>
+            <th:block th:if="${isInterestedInECE}">
+                <h2 class="h2" th:text="#{ece-yes-confirmation.header}"></h2>
+            </th:block>
+            <th:block th:unless="${isInterestedInECE}">
+                <h2 class="h2" th:text="#{ece-no-confirmation.header}"></h2>
+            </th:block>
+            <p th:text="#{nola-ece-links.if-youre-approved}"></p>
+            <p th:utext="#{nola-ece-links.subheader}"></p>
+            <a class="button button--primary" href="http://apply.avela.org/nolaps"
+               th:text="#{nola-ece-go-to-application}"></a>
+        </th:block>
+
+        <th:block th:if="${inLinkGroup}">
+            <hr>
+            <th:block th:if="${isInterestedInWIC}">
+                <h2 class="h2" th:text="#{wic-yes-confirmation.header}"></h2>
+            </th:block>
+            <th:block th:unless="${isInterestedInWIC}">
+                <h2 class="h2" th:text="#{wic-no-confirmation.header}"></h2>
+            </th:block>
+            <p th:text="#{wic.if-youre-approved}"></p>
+            <p th:utext="#{wic.subheader}"></p>
+            <a class="button button--primary" href="https://mywic.net/participantreferral"
+               th:text="#{wic-go-to-application}"></a>
+        </th:block>
+    </th:block>
+</th:block>

--- a/src/main/resources/templates/laDigitalAssister/confirmation.html
+++ b/src/main/resources/templates/laDigitalAssister/confirmation.html
@@ -18,7 +18,7 @@
         <th:block
             th:replace="~{fragments/form :: form(action=${formAction}, content=~{::formContent})}">
           <th:block th:ref="formContent">
-            <th:block th:replace="~{'fragments/reveal' :: reveal(
+            <th:block th:replace="~{'fragments/honeycrisp/reveal' :: reveal(
                 controlId='r1',
                 linkLabel=~{::revealLabel1},
                 content=~{::revealContent1},
@@ -35,8 +35,9 @@
               </th:block>
             </th:block>
 
-            <hr>
+            <div th:replace="~{fragments/wicEceConfirmation :: wicEceConfirmation}"></div>
 
+            <hr>
             <h2 class="h2" th:text="#{confirmation.next-steps}"></h2>
 
             <div class="vertical-steps">

--- a/src/main/resources/templates/laDigitalAssister/nolaEceLinks.html
+++ b/src/main/resources/templates/laDigitalAssister/nolaEceLinks.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}">
-<head th:replace="~{fragments/head :: head(title=#{nola.title})}"></head>
+<head th:replace="~{fragments/head :: head(title=#{nola-ece-links.title})}"></head>
 <body>
 <div class="page-wrapper">
     <div th:replace="~{fragments/toolbar :: toolbar}"></div>

--- a/src/main/resources/templates/laDigitalAssister/nolaEceLinks.html
+++ b/src/main/resources/templates/laDigitalAssister/nolaEceLinks.html
@@ -7,17 +7,26 @@
     <section class="slab">
         <div class="grid">
             <div th:replace="~{fragments/goBack :: goBackLink}"></div>
-            <main id="content" role="main" class="form-card spacing-above-35">
+            <main id="content" role="main" class="form-card spacing-above-35"
+                th:with="header=|#{general.good-news} #{nola-ece-links.if-youre-approved}|">
                 <th:block th:replace="~{fragments/icons :: choosePrograms}"></th:block>
                 <th:block
-                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{nola-ece-links.header}, subtext=#{nola-ece-links.subheader})}"/>
+                        th:replace="~{fragments/cardHeader :: cardHeader(header=${header}, subtext=#{nola-ece-links.subheader})}"/>
 
-                <div class="form-card__footer spacing-below-60">
-                    <a class="button button--primary" href="http://apply.avela.org/nolaps"
-                       th:text="#{nola-ece-links-button}"></a>
-                    <a class="button button--secondary spacing-left-0" th:href="|/flow/${flow}/${screen}/navigation|"
-                       th:text="#{general.continue-with-snap-only}"></a>
+                <div class="notice-info">
+                    <span class="spacing-below-25" th:text="#{nola-ece-links.at-the-end-of-this-app}"></span>
                 </div>
+                <th:block
+                        th:replace="'fragments/form' :: form(action=('/flow/' + ${flow} + '/'+ ${screen} + '/submit' ), content=~{::submitForm})">
+                    <th:block th:ref="submitForm">
+                        <div class="form-card__footer spacing-below-60">
+                            <th:block th:replace="~{fragments/inputs/yesOrNo :: yesOrNo(
+                      label=#{nola-ece-links.are-you-interested},
+                      inputName='interestedInEceInd',
+                      ariaDescribe='header')}"/>
+                        </div>
+                    </th:block>
+                </th:block>
             </main>
         </div>
     </section>

--- a/src/main/resources/templates/laDigitalAssister/nolaEceLinks.html
+++ b/src/main/resources/templates/laDigitalAssister/nolaEceLinks.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}">
+<head th:replace="~{fragments/head :: head(title=#{nola.title})}"></head>
+<body>
+<div class="page-wrapper">
+    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+    <section class="slab">
+        <div class="grid">
+            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+            <main id="content" role="main" class="form-card spacing-above-35">
+                <th:block th:replace="~{fragments/icons :: choosePrograms}"></th:block>
+                <th:block
+                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{nola-ece-links.header}, subtext=#{nola-ece-links.subheader})}"/>
+
+                <div class="form-card__footer spacing-below-60">
+                    <a class="button button--primary" href="http://apply.avela.org/nolaps"
+                       th:text="#{nola-ece-links-button}"></a>
+                    <a class="button button--secondary spacing-left-0" th:href="|/flow/${flow}/${screen}/navigation|"
+                       th:text="#{general.continue-with-snap-only}"></a>
+                </div>
+            </main>
+        </div>
+    </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/laDigitalAssister/wicLinks.html
+++ b/src/main/resources/templates/laDigitalAssister/wicLinks.html
@@ -10,14 +10,22 @@
             <main id="content" role="main" class="form-card spacing-above-35">
                 <th:block th:replace="~{fragments/icons :: choosePrograms}"></th:block>
                 <th:block
-                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{wic.header}, subtext=#{wic.based-on-your-answers})}"/>
+                        th:replace="~{fragments/cardHeader :: cardHeader(header=|#{general.good-news} #{wic.if-youre-approved}|, subtext=#{wic.subheader})}"/>
 
-                <div class="form-card__footer spacing-below-60">
-                    <a class="button button--primary" href="https://mywic.net/participantreferral"
-                       th:text="#{wic-links-button}"></a>
-                    <a class="button button--secondary spacing-left-0" th:href="|/flow/${flow}/${screen}/navigation|"
-                       th:text="#{general.continue-with-snap-only}"></a>
+                <div class="notice-info">
+                    <span class="spacing-below-25" th:text="#{wic-links.at-the-end-of-this-app}"></span>
                 </div>
+                <th:block
+                        th:replace="'fragments/form' :: form(action=('/flow/' + ${flow} + '/'+ ${screen} + '/submit' ), content=~{::submitForm})">
+                    <th:block th:ref="submitForm">
+                        <div class="form-card__footer spacing-below-60">
+                            <th:block th:replace="~{fragments/inputs/yesOrNo :: yesOrNo(
+                              label=#{wic-links.are-you-interested},
+                              inputName='interestedInWicInd',
+                              ariaDescribe='header')}"/>
+                        </div>
+                    </th:block>
+                </th:block>
             </main>
         </div>
     </section>

--- a/src/main/resources/templates/laDigitalAssister/wicLinks.html
+++ b/src/main/resources/templates/laDigitalAssister/wicLinks.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html th:lang="${#locale.language}">
-<head th:replace="~{fragments/head :: head(title=#{wic.title})}"></head>
+<head th:replace="~{fragments/head :: head(title=#{wic-links.title})}"></head>
 <body>
 <div class="page-wrapper">
     <div th:replace="~{fragments/toolbar :: toolbar}"></div>

--- a/src/main/resources/templates/laDigitalAssister/wicLinks.html
+++ b/src/main/resources/templates/laDigitalAssister/wicLinks.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}">
+<head th:replace="~{fragments/head :: head(title=#{wic.title})}"></head>
+<body>
+<div class="page-wrapper">
+    <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+    <section class="slab">
+        <div class="grid">
+            <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+            <main id="content" role="main" class="form-card spacing-above-35">
+                <th:block th:replace="~{fragments/icons :: choosePrograms}"></th:block>
+                <th:block
+                        th:replace="~{fragments/cardHeader :: cardHeader(header=#{wic.header}, subtext=#{wic.based-on-your-answers})}"/>
+
+                <div class="form-card__footer spacing-below-60">
+                    <a class="button button--primary" href="https://mywic.net/participantreferral"
+                       th:text="#{wic-links-button}"></a>
+                    <a class="button button--secondary spacing-left-0" th:href="|/flow/${flow}/${screen}/navigation|"
+                       th:text="#{general.continue-with-snap-only}"></a>
+                </div>
+            </main>
+        </div>
+    </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/test/java/org/ladocuploader/app/journeys/LaDigitalAssisterFlowJourneyTest.java
+++ b/src/test/java/org/ladocuploader/app/journeys/LaDigitalAssisterFlowJourneyTest.java
@@ -647,7 +647,16 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     testPage.goBack();
     testPage.clickButton("No");
 
-    //    Final SignPost
+    var title = testPage.getTitle();
+    if ("ECE link".equals(title)) {
+      testPage.clickButton("Yes");
+      assertThat(testPage.getTitle()).isEqualTo("WIC link");
+      testPage.clickButton("Yes");
+    } else if ("WIC link".equals(title)) {
+      testPage.clickButton("Yes");
+    }
+
+    // Final SignPost
     assertThat(testPage.getTitle()).isEqualTo(message("final-signpost.title"));
     testPage.clickContinue();
 

--- a/src/test/java/org/ladocuploader/app/journeys/LaDigitalAssisterFlowJourneyTest.java
+++ b/src/test/java/org/ladocuploader/app/journeys/LaDigitalAssisterFlowJourneyTest.java
@@ -14,25 +14,26 @@ import static org.awaitility.Awaitility.await;
 @Slf4j
 public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
 
-  protected static final String RANGE_ERROR_MESSAGE="Make sure to provide a value between 1 and 100.";
+  protected static final String RANGE_ERROR_MESSAGE = "Make sure to provide a value between 1 and 100.";
 
   @Test
   void chooseProgramsFlow() {
     testPage.navigateToFlowScreen("laDigitalAssister/choosePrograms");
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(message("error.missing-general")));
+    assert (testPage.hasErrorText(message("error.missing-general")));
     testPage.clickElementById("programs-SNAP");
     testPage.clickContinue();
 
     assertThat(testPage.getTitle()).isEqualTo(message("expedited-snap.title"));
   }
+
   @Test
   void whosApplyingFlow() {
     testPage.navigateToFlowScreen("laDigitalAssister/whosApplying");
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(message("error.missing-general")));
+    assert (testPage.hasErrorText(message("error.missing-general")));
     testPage.clickElementById("whosApplying-Self");
     testPage.clickContinue();
 
@@ -48,9 +49,9 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     testPage.enter("birthDay", "25");
     testPage.enter("birthYear", "1985");
 
-    assert(testPage.hasErrorText(message("error.missing-firstname")));
-    assert(testPage.hasErrorText(message("error.missing-lastname")));
-    assert(testPage.hasErrorText(message("error.missing-general")));
+    assert (testPage.hasErrorText(message("error.missing-firstname")));
+    assert (testPage.hasErrorText(message("error.missing-lastname")));
+    assert (testPage.hasErrorText(message("error.missing-general")));
 
     testPage.enter("firstName", "test");
     testPage.enter("lastName", "test2");
@@ -62,7 +63,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
   }
 
   @Test
-  void hourlyIncomeFlow(){
+  void hourlyIncomeFlow() {
     loadUserPersonalData();
     loadHouseHoldData("First", "User", "12", "22", "1991");
     loadHouseHoldData("Second", "User", "01", "23", "1997");
@@ -73,7 +74,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
 
     assertThat(testPage.getTitle()).isEqualTo(message("income-who.title"));
     testPage.clickContinue();
-    assert(testPage.hasErrorText(message("error.missing-general")));
+    assert (testPage.hasErrorText(message("error.missing-general")));
 
     testPage.clickElementById("householdMemberJobAdd-you");
     testPage.clickContinue();
@@ -81,7 +82,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     assertThat(testPage.getTitle()).isEqualTo(message("employer-name.title"));
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(message("error.missing-general")));
+    assert (testPage.hasErrorText(message("error.missing-general")));
     testPage.enter("employerName", "job1");
 
     testPage.clickContinue();
@@ -95,11 +96,11 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     assertThat(testPage.getTitle()).isEqualTo(message("job-hourly-wage.title"));
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(message("error.missing-dollar-amount")));
+    assert (testPage.hasErrorText(message("error.missing-dollar-amount")));
     testPage.enter("hourlyWage", "a");
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(message("error.invalid-money")));
+    assert (testPage.hasErrorText(message("error.invalid-money")));
     testPage.enter("hourlyWage", ".99");
 
     testPage.clickContinue();
@@ -107,13 +108,13 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     assertThat(testPage.getTitle()).isEqualTo(message("job-hours-per-week.title"));
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(RANGE_ERROR_MESSAGE));
-    assert(testPage.hasErrorText(message("error.missing-general")));
+    assert (testPage.hasErrorText(RANGE_ERROR_MESSAGE));
+    assert (testPage.hasErrorText(message("error.missing-general")));
 
     testPage.enter("hoursPerWeek", "100000");
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(RANGE_ERROR_MESSAGE));
+    assert (testPage.hasErrorText(RANGE_ERROR_MESSAGE));
 
     testPage.enter("hoursPerWeek", "10");
     testPage.clickContinue();
@@ -122,7 +123,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
   }
 
   @Test
-  void monthlyIncomeFlow(){
+  void monthlyIncomeFlow() {
     loadUserPersonalData();
     loadHouseHoldData("Third", "User", "12", "22", "1991");
     loadHouseHoldData("Fourth", "User", "01", "23", "1997");
@@ -134,11 +135,11 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     assertThat(testPage.getTitle()).isEqualTo(message("household-annual-income.title"));
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(message("error.missing-dollar-amount")));
+    assert (testPage.hasErrorText(message("error.missing-dollar-amount")));
     testPage.enter("monthlyHouseholdIncome", "abc");
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(message("error.invalid-money")));
+    assert (testPage.hasErrorText(message("error.invalid-money")));
     testPage.enter("monthlyHouseholdIncome", "1286.55");
 
     testPage.clickContinue();
@@ -147,7 +148,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
   }
 
   @Test
-  void otherIncomeFlow(){
+  void otherIncomeFlow() {
     loadUserPersonalData();
     loadHouseHoldData("Third", "User", "12", "22", "1991");
     loadHouseHoldData("Fourth", "User", "01", "23", "1997");
@@ -158,7 +159,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
 
     assertThat(testPage.getTitle()).isEqualTo(message("income-who.title"));
     testPage.clickContinue();
-    assert(testPage.hasErrorText(message("error.missing-general")));
+    assert (testPage.hasErrorText(message("error.missing-general")));
 
     testPage.clickElementById("householdMemberJobAdd-you");
     testPage.clickContinue();
@@ -166,7 +167,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     assertThat(testPage.getTitle()).isEqualTo(message("employer-name.title"));
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(message("error.missing-general")));
+    assert (testPage.hasErrorText(message("error.missing-general")));
     testPage.enter("employerName", "job1");
 
     testPage.clickContinue();
@@ -178,7 +179,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     testPage.clickButton("No");
 
     testPage.clickContinue();
-    assert(testPage.hasErrorText(message("error.missing-pay-period")));
+    assert (testPage.hasErrorText(message("error.missing-pay-period")));
 
     testPage.selectRadio("payPeriod", "Every month");
     testPage.clickContinue();
@@ -188,7 +189,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     testPage.enter("payPeriodAmount", "a");
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(message("error.invalid-money")));
+    assert (testPage.hasErrorText(message("error.invalid-money")));
     testPage.enter("payPeriodAmount", "282.99");
 
     testPage.clickContinue();
@@ -197,7 +198,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
   }
 
   @Test
-  void socialSecurityFlow(){
+  void socialSecurityFlow() {
     loadUserPersonalData();
 
     testPage.navigateToFlowScreen("laDigitalAssister/ssnForm");
@@ -207,7 +208,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     testPage.enter("ssn", "1234");
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(message("error.invalid-ssn")));
+    assert (testPage.hasErrorText(message("error.invalid-ssn")));
     testPage.enter("ssn", "");
     testPage.clickContinue();
 
@@ -652,8 +653,6 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
       testPage.clickButton("Yes");
       assertThat(testPage.getTitle()).isEqualTo("WIC link");
       testPage.clickButton("Yes");
-    } else if ("WIC link".equals(title)) {
-      testPage.clickButton("Yes");
     }
 
     // Final SignPost
@@ -743,7 +742,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     uploadJpgFile();
     // give the system time to remove the "display-none" class.
     await().atMost(5, TimeUnit.SECONDS).until(
-            () -> !(testPage.findElementById("form-submit-button").getAttribute("class").contains("display-none"))
+        () -> !(testPage.findElementById("form-submit-button").getAttribute("class").contains("display-none"))
     );
 
     testPage.clickContinue();
@@ -781,9 +780,8 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     assertThat(testPage.getTitle()).isEqualTo(message("confirmation.title"));
 
 
-
-
   }
+
   void loadUserPersonalData() {
     testPage.navigateToFlowScreen("laDigitalAssister/personalInfo");
 
@@ -808,7 +806,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     testPage.clickContinue();
   }
 
-  void preloadIncomeScreen(){
+  void preloadIncomeScreen() {
     testPage.navigateToFlowScreen("laDigitalAssister/incomeSignPost");
     testPage.clickContinue();
 
@@ -817,7 +815,7 @@ public class LaDigitalAssisterFlowJourneyTest extends AbstractBasePageTest {
     assertThat(testPage.getTitle()).isEqualTo(message("job-search-who.title"));
     testPage.clickContinue();
 
-    assert(testPage.hasErrorText(message("error.missing-general")));
+    assert (testPage.hasErrorText(message("error.missing-general")));
 
     testPage.clickElementById("jobSearch-you");
     testPage.clickContinue();


### PR DESCRIPTION
Adding screens for treatment group 1 - "links" and conditional navigation for experiment
[Figma designs](https://www.figma.com/file/atMAV1gBwc9HdAIymWOKIc/Digital-Assister---All-Designs?type=design&node-id=4527-19279&mode=design&t=37ph0otSBX79fmBm-0)

Does not include Treatment group 2 - apply. This will be added in a follow-up PR

---
Testing Steps

1. [Select parish (NOLA vs not-NOLA)](https://test-la-doc-uploader-pr-458.herokuapp.com/flow/laDigitalAssister/parish)
2. [Trigger treatment grouping ](https://test-la-doc-uploader-pr-458.herokuapp.com/flow/laDigitalAssister/languagePreference) - this is currently random, might need to trigger it a few times to get the LINKS treatment
3. [Jump to screen before wic/ece screens](https://test-la-doc-uploader-pr-458.herokuapp.com/flow/laDigitalAssister/expensesElderlyCare) 
4. Verify WIC/ECE screens - depends on treatment
5. [Jump to signature page](https://test-la-doc-uploader-pr-458.herokuapp.com/flow/laDigitalAssister/signature) and continue to confirmation
6. Verify confirmation blocks - depends on treatment

