### PR TITLE
Simplifying experiment allocation

### DIFF
--- a/src/main/java/org/ladocuploader/app/data/validators/DateRangeValidator.java
+++ b/src/main/java/org/ladocuploader/app/data/validators/DateRangeValidator.java
@@ -1,18 +1,19 @@
 package org.ladocuploader.app.data.validators;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.extern.slf4j.Slf4j;
 
+
+import static org.ladocuploader.app.data.validators.DateValidator.MM_DD_YYYY;
+
 @Slf4j
 public class DateRangeValidator implements ConstraintValidator<DateWithinRange, List<String>> {
 
   static final LocalDate MIN_DATE = LocalDate.of(1900, 1, 1);
-  static final DateTimeFormatter MM_DD_YYYY = DateTimeFormatter.ofPattern("M/d/uuuu");
 
   @Override
   public void initialize(DateWithinRange constraintAnnotation) {

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -120,7 +120,6 @@ flow:
     nextScreens:
       - name: householdSchool
   householdSchool:
-    beforeSaveAction: SetExperimentGroups
     nextScreens:
       - name: householdSchoolWho
         condition: GoingToSchool
@@ -133,6 +132,7 @@ flow:
     nextScreens:
       - name: householdPregnancy
   householdPregnancy:
+    beforeSaveAction: SetExperimentGroups
     nextScreens:
       - name: householdPregnancyWho
         condition: IsPregnant

--- a/src/test/java/org/ladocuploader/app/data/SubmissionTestBuilder.java
+++ b/src/test/java/org/ladocuploader/app/data/SubmissionTestBuilder.java
@@ -81,6 +81,7 @@ public class SubmissionTestBuilder {
     }
 
     public SubmissionTestBuilder withPregnancies(List<String> uuids) {
+        submission.getInputData().put("pregnancyInd", "true");
         submission.getInputData().put("pregnancies[]", uuids);
         return this;
     }


### PR DESCRIPTION
- Changed pregnancy check to use the indicator value
- Reusing date parser from date validation
- Moved SetExperiment action to after pregnancy question (instead of before)